### PR TITLE
feat(blog): カバー画像生成をデフォルト OFF にする（オプトイン化）

### DIFF
--- a/scripts/daily-blog.ts
+++ b/scripts/daily-blog.ts
@@ -23,6 +23,7 @@ function loadDotenv(file = '.env.local') {
 loadDotenv();
 
 const DRY_RUN = process.argv.includes('--dry-run') || process.env.BLOG_DRY_RUN === '1';
+const NO_COVER = process.argv.includes('--no-cover') || process.env.BLOG_NO_COVER === '1';
 
 async function main() {
   const supabase = createClient<Database>(
@@ -55,20 +56,26 @@ async function main() {
   console.log(`  ✓ body: ${post.body.length} chars`);
   console.log(`  ✓ hashtags: ${post.hashtags.join(' ')}`);
 
-  console.log('\n2/3 Generating cover image (Nano Banana)…');
-  const { pngBuffer, model: coverModel } = await generateCoverImage({
-    title: post.title,
-    tags: article.tags,
-    summary: article.ai_summary,
-  });
-  console.log(`  ✓ ${pngBuffer.length.toLocaleString()} bytes, model ${coverModel}`);
+  let pngBuffer: Buffer | undefined;
+  if (NO_COVER) {
+    console.log('\n2/3 Cover image SKIPPED (--no-cover / BLOG_NO_COVER=1)');
+  } else {
+    console.log('\n2/3 Generating cover image (Nano Banana)…');
+    const cover = await generateCoverImage({
+      title: post.title,
+      tags: article.tags,
+      summary: article.ai_summary,
+    });
+    pngBuffer = cover.pngBuffer;
+    console.log(`  ✓ ${pngBuffer.length.toLocaleString()} bytes, model ${cover.model}`);
+  }
 
   // Save locally
   const stamp = new Date().toISOString().slice(0, 10);
   const dir = path.join('drafts', `${stamp}_${article.id.slice(0, 8)}`);
   fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(path.join(dir, 'post.md'), `# ${post.title}\n\n${post.body}\n\n${post.hashtags.join(' ')}\n`);
-  fs.writeFileSync(path.join(dir, 'cover.png'), pngBuffer);
+  if (pngBuffer) fs.writeFileSync(path.join(dir, 'cover.png'), pngBuffer);
   fs.writeFileSync(
     path.join(dir, 'meta.json'),
     JSON.stringify({ article_id: article.id, source_url: article.source_url, post }, null, 2),
@@ -87,7 +94,7 @@ async function main() {
       title: post.title,
       body: post.body,
       hashtags: post.hashtags,
-      coverPng: pngBuffer,
+      ...(pngBuffer ? { coverPng: pngBuffer } : {}),
     });
     draftUrl = result.draftUrl;
     console.log(`  ✓ draft URL: ${draftUrl}`);

--- a/scripts/daily-blog.ts
+++ b/scripts/daily-blog.ts
@@ -23,7 +23,9 @@ function loadDotenv(file = '.env.local') {
 loadDotenv();
 
 const DRY_RUN = process.argv.includes('--dry-run') || process.env.BLOG_DRY_RUN === '1';
-const NO_COVER = process.argv.includes('--no-cover') || process.env.BLOG_NO_COVER === '1';
+// Cover image generation (Gemini 2.5 Flash Image / Nano Banana) is metered,
+// so it's opt-in. Pass --cover or BLOG_COVER=1 to generate one.
+const COVER = process.argv.includes('--cover') || process.env.BLOG_COVER === '1';
 
 async function main() {
   const supabase = createClient<Database>(
@@ -57,9 +59,7 @@ async function main() {
   console.log(`  ✓ hashtags: ${post.hashtags.join(' ')}`);
 
   let pngBuffer: Buffer | undefined;
-  if (NO_COVER) {
-    console.log('\n2/3 Cover image SKIPPED (--no-cover / BLOG_NO_COVER=1)');
-  } else {
+  if (COVER) {
     console.log('\n2/3 Generating cover image (Nano Banana)…');
     const cover = await generateCoverImage({
       title: post.title,
@@ -68,6 +68,8 @@ async function main() {
     });
     pngBuffer = cover.pngBuffer;
     console.log(`  ✓ ${pngBuffer.length.toLocaleString()} bytes, model ${cover.model}`);
+  } else {
+    console.log('\n2/3 Cover image skipped (default; pass --cover or BLOG_COVER=1 to enable)');
   }
 
   // Save locally


### PR DESCRIPTION
## 概要
- `scripts/daily-blog.ts` のカバー画像生成（Gemini 2.5 Flash Image / Nano Banana）を **デフォルト OFF** に変更
- 必要なときだけ `--cover` フラグまたは `BLOG_COVER=1` でオプトイン
- launchd の毎朝 06:00 自動実行も同様にカバー無しになる（plist で `--cover` を渡せば従来通り生成可能）

## 背景
Nano Banana は画像 1 枚ごとに従量課金。普段の自動実行ではカバー無しで運用し、必要時のみ手動で `--cover` を付けて再実行することで月額コストをゼロに近づける。

## 使い方
```bash
# 通常（カバーなし。launchd もこれ）
npx tsx scripts/daily-blog.ts

# カバーを生成したい時だけ
npx tsx scripts/daily-blog.ts --cover
BLOG_COVER=1 npx tsx scripts/daily-blog.ts
```

## 検証方針
- [x] `npx tsc --noEmit` パス
- [ ] 手動: フラグなしで実行 → ログに `Cover image skipped (default; ...)` が出ること、新しい drafts フォルダに `cover.png` が無いこと、note 下書きが本文のみで保存されることを確認
- [ ] 手動: `--cover` 付きで実行 → 従来どおりカバー画像が生成・添付されることを確認
- [ ] 必要なら `~/Library/LaunchAgents/com.kagoshima-circular-hub.blog.plist` の起動コマンドに `--cover` を追加するか判断

🤖 Generated with [Claude Code](https://claude.com/claude-code)