### PR TITLE
feat(regulations): JETROビジネス短信・環境省審議会の専用スクレイパー追加

### DIFF
--- a/src/lib/aggregate.ts
+++ b/src/lib/aggregate.ts
@@ -10,6 +10,8 @@ import { envGoJpScraper } from '@/lib/scrapers/env-go-jp';
 import { metiScraper } from '@/lib/scrapers/meti';
 import { maffScraper } from '@/lib/scrapers/maff';
 import { soumuScraper } from '@/lib/scrapers/soumu';
+import { jetroScraper } from '@/lib/scrapers/jetro';
+import { envCouncilScraper } from '@/lib/scrapers/env-council';
 import { domesticCasesScraper } from '@/lib/scrapers/domestic-cases';
 import { fetchArticlePage } from '@/lib/scrapers/body';
 import { extractRegulationTags } from '@/lib/scrapers/common';
@@ -32,6 +34,8 @@ const SCRAPERS = [
   metiScraper,
   maffScraper,
   soumuScraper,
+  jetroScraper,
+  envCouncilScraper,
   domesticCasesScraper,
 ];
 const BODY_BATCH = 40;

--- a/src/lib/scrapers/env-council.ts
+++ b/src/lib/scrapers/env-council.ts
@@ -1,0 +1,109 @@
+import * as cheerio from 'cheerio';
+import { REGULATION_TAG, extractTags, fetchText, resolveUrl } from './common';
+import type { Scraper, ScrapedArticle } from './types';
+
+// 中央環境審議会 循環型社会部会とその現役小委員会の開催実績。
+// 資源有効利用促進法改正・太陽光パネルリサイクル制度などの法制化は
+// プレスリリースより先にここで審議されるため、/regulations の一次情報
+// として法規制タグを必ず付与する。
+//
+// ページ構成: 部会トップに「令和◯年◯月◯日 会合名 議事次第・配布資料／議事録」
+// 形式の <li> が並び、「小委員会・専門委員会」見出しの下に現役小委員会への
+// リンクがある（「廃止された小委員会」「旧部会」配下は追わない）。
+const INDEX_URL = 'https://www.env.go.jp/council/03recycle/yoshi03.html';
+const SOURCE_NAME = '環境省 審議会';
+// 過去会合まで遡ると初回実行で数百件が一気に入りメール配信が溢れるため、
+// 直近の会合だけを扱う。
+const RECENT_DAYS = 180;
+const MAX_SUBCOMMITTEES = 15;
+
+const ERA_DATE_RE = /^(令和|平成)([0-9０-９]+|元)年([0-9０-９]+)月([0-9０-９]+)日/;
+// li 末尾のリンクラベル（配布/配付の表記ゆれあり）を会合名から取り除く。
+const LINK_LABEL_RE = /(議事次第(・配[布付]資料)?|配[布付]資料|議事録|議事要旨|／)/g;
+
+function toHalfWidth(s: string): string {
+  return s.replace(/[０-９]/g, (c) => String.fromCharCode(c.charCodeAt(0) - 0xfee0));
+}
+
+function parseEraDate(era: string, year: string, month: string, day: string): Date | null {
+  const y = (era === '令和' ? 2018 : 1988) + (year === '元' ? 1 : Number(toHalfWidth(year)));
+  const d = new Date(`${y}-${toHalfWidth(month).padStart(2, '0')}-${toHalfWidth(day).padStart(2, '0')}T00:00:00+09:00`);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+interface Meeting {
+  title: string;
+  url: string;
+  publishedAt: string;
+}
+
+function parseMeetings(html: string, pageUrl: string, since: Date): Meeting[] {
+  const $ = cheerio.load(html);
+  const out: Meeting[] = [];
+  $('main li, #main li, .l-main li').each((_, el) => {
+    const li = $(el);
+    const text = li.text().replace(/\s+/g, ' ').trim();
+    const m = ERA_DATE_RE.exec(text);
+    if (!m) return;
+    const date = parseEraDate(m[1], m[2], m[3], m[4]);
+    if (!date || date < since) return;
+    const href = li.find('a').first().attr('href');
+    if (!href) return;
+    const name = text.slice(m[0].length).replace(LINK_LABEL_RE, '').replace(/\s+/g, ' ').trim();
+    if (!name) return;
+    out.push({
+      title: name,
+      url: resolveUrl(pageUrl, href),
+      publishedAt: date.toISOString(),
+    });
+  });
+  return out;
+}
+
+// 「小委員会・専門委員会」見出しから次の見出しまでのリンクだけを現役とみなす。
+function activeSubcommitteeUrls(html: string): string[] {
+  const $ = cheerio.load(html);
+  const urls: string[] = [];
+  $('h2').each((_, el) => {
+    const h2 = $(el);
+    if (!h2.text().includes('小委員会・専門委員会')) return;
+    h2.nextUntil('h2').find('a[href]').each((_, a) => {
+      const url = resolveUrl(INDEX_URL, $(a).attr('href') ?? '');
+      if (url.startsWith('https://www.env.go.jp/') && !urls.includes(url)) urls.push(url);
+    });
+  });
+  return urls.slice(0, MAX_SUBCOMMITTEES);
+}
+
+export const envCouncilScraper: Scraper = {
+  name: 'env-council',
+  async run(): Promise<ScrapedArticle[]> {
+    const since = new Date(Date.now() - RECENT_DAYS * 24 * 60 * 60 * 1000);
+    const indexHtml = await fetchText(INDEX_URL);
+    const meetings = parseMeetings(indexHtml, INDEX_URL, since);
+
+    const errors: string[] = [];
+    for (const pageUrl of activeSubcommitteeUrls(indexHtml)) {
+      try {
+        meetings.push(...parseMeetings(await fetchText(pageUrl), pageUrl, since));
+      } catch (e) {
+        errors.push(`${pageUrl}: ${(e as Error).message}`);
+      }
+    }
+    if (errors.length > 0) console.error('[env-council] partial failure:', errors.join(' / '));
+
+    const seen = new Set<string>();
+    return meetings
+      .filter((m) => (seen.has(m.url) ? false : (seen.add(m.url), true)))
+      .map((m) => ({
+        source_type: 'national' as const,
+        source_id: 'env-council',
+        source_name: SOURCE_NAME,
+        source_url: m.url,
+        title: m.title,
+        published_at: m.publishedAt,
+        raw_excerpt: null,
+        tags: [...new Set([REGULATION_TAG, ...extractTags(m.title)])],
+      }));
+  },
+};

--- a/src/lib/scrapers/jetro.ts
+++ b/src/lib/scrapers/jetro.ts
@@ -1,0 +1,31 @@
+import { extractRegulationTags, extractTags, fetchText, parseRssItems } from './common';
+import type { Scraper, ScrapedArticle } from './types';
+
+// JETRO ビジネス短信 — 世界の通商・規制ニュース。CE 関連の法規制
+// (CBAM, ESPR, 電池規則 …) の一次報道が厚いが、フィード全体は規制と
+// 無関係な経済ニュースが大半なので、法規制キーワードに一致した記事
+// だけを採用する。Shown on /regulations (and the top feed) via the
+// 法規制 tag.
+const RSS_URL = 'https://www.jetro.go.jp/rss2/biznews.xml';
+
+export const jetroScraper: Scraper = {
+  name: 'jetro-biznews',
+  async run(): Promise<ScrapedArticle[]> {
+    const xml = await fetchText(RSS_URL);
+    const out: ScrapedArticle[] = [];
+    for (const item of parseRssItems(xml)) {
+      if (extractRegulationTags(item.title).length === 0) continue;
+      out.push({
+        source_type: 'national',
+        source_id: 'jetro.go.jp',
+        source_name: 'JETROビジネス短信',
+        source_url: item.link,
+        title: item.title,
+        published_at: item.publishedAt,
+        raw_excerpt: null,
+        tags: extractTags(item.title),
+      });
+    }
+    return out;
+  },
+};


### PR DESCRIPTION
## Summary
法規制ページ (/regulations) の情報源を強化する専用スクレイパーを2つ追加し、既存の1日4回の定期集約に組み込みました。

- **jetro-biznews** (`src/lib/scrapers/jetro.ts`): JETRO ビジネス短信 RSS (`https://www.jetro.go.jp/rss2/biznews.xml`) を巡回。フィード全体は一般経済ニュースが大半のため、法規制キーワード (CBAM・ESPR・電池規則・PPWR・EUDR・DPP 等) に一致した記事のみ採用。
- **env-council** (`src/lib/scrapers/env-council.ts`): 中央環境審議会 循環型社会部会と「小委員会・専門委員会」配下の現役小委員会ページを巡回し、開催実績（議事次第・配布資料）を収集。
  - 過去会合まで遡ると初回に数百件が投入されメール配信 (1記事1通) が溢れるため、**直近180日の会合のみ**対象。
  - 会合名には法規制キーワードが含まれないことが多いため、`法規制` タグを強制付与して /regulations に表示。
  - 令和/平成の和暦日付（全角数字混在）を ISO に変換して `published_at` に設定。

## Test plan
- [x] JETRO RSS の実在・フォーマットを実フェッチで検証（RSS 2.0、20件/回）
- [x] 法規制キーワードフィルタを実在タイトル7例で検証（規制記事のみ採用、一般ニュース除外）
- [x] env-council を実サイトに対して実行 → 7件取得（全て180日以内、日付・タグ・URL正常。旧レイアウトの小委員会ページも li パターンで対応）
- [x] `npm run build` / `npm run lint` 成功
- [ ] マージ後、次回の定期集約 (GitHub Actions) で両ソースの記事が挿入され /regulations に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)