### PR TITLE
feat(regulation-check): ストリーミング応答と結果の共有URL

### DIFF
--- a/src/app/api/regulation-check/route.ts
+++ b/src/app/api/regulation-check/route.ts
@@ -3,7 +3,7 @@ import Anthropic from '@anthropic-ai/sdk';
 import { supabaseAdmin } from '@/lib/supabase';
 import { embedTexts } from '@/lib/ai/embeddings';
 import { REGULATION_TAG } from '@/lib/scrapers/common';
-import type { MatchedArticle } from '@/lib/database.types';
+import type { MatchedArticle, RegulationCheckSource } from '@/lib/database.types';
 
 export const runtime = 'nodejs';
 export const maxDuration = 60;
@@ -41,6 +41,11 @@ const SYSTEM_PROMPT = `あなたは鹿児島県の中小企業の実務担当者
 - 対象外と思われる規制は無理に含めない。入力が製品・部品・素材名として解釈できない場合は、その旨を短く伝えて例を示す
 - 全体で600字程度まで。法的助言ではなく情報整理であることを踏まえ、断定を避ける`;
 
+// SSE line: data: {"type":"sources"|"delta"|"done"|"error", ...}\n\n
+function sse(payload: Record<string, unknown>): string {
+  return `data: ${JSON.stringify(payload)}\n\n`;
+}
+
 export async function POST(req: Request) {
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) return NextResponse.json({ error: 'AI機能が未設定です' }, { status: 503 });
@@ -61,11 +66,13 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: `製品・部品名は2〜${MAX_INPUT_CHARS}文字で入力してください` }, { status: 400 });
   }
 
+  const admin = supabaseAdmin();
+
   // Retrieve regulation articles semantically close to the product.
   let related: MatchedArticle[] = [];
   try {
     const [vector] = await embedTexts([`${product} に関係する法規制・義務・報告要件`]);
-    const { data, error } = await supabaseAdmin().rpc('match_news_articles', {
+    const { data, error } = await admin.rpc('match_news_articles', {
       query_embedding: JSON.stringify(vector),
       match_count: RETRIEVE_COUNT,
     });
@@ -87,39 +94,66 @@ export async function POST(req: Request) {
         .join('\n\n')
     : '（関連する収集記事なし — 一般知識のみで簡潔に回答し、その旨を明記すること）';
 
-  const client = new Anthropic({ apiKey });
-  let answer: string;
-  try {
-    const res = await client.messages.create({
-      model: MODEL,
-      max_tokens: 1500,
-      temperature: 0.2,
-      system: SYSTEM_PROMPT,
-      messages: [
-        {
-          role: 'user',
-          content: `製品・部品名: ${product}\n\n参考記事（当サイトが収集した法規制関連記事）:\n${articleContext}`,
-        },
-      ],
-    });
-    answer = res.content
-      .filter((b): b is Anthropic.TextBlock => b.type === 'text')
-      .map((b) => b.text)
-      .join('\n')
-      .trim();
-  } catch (e) {
-    return NextResponse.json({ error: `AI応答の生成に失敗しました: ${(e as Error).message}` }, { status: 502 });
-  }
+  const sources: RegulationCheckSource[] = related.map((a) => ({
+    id: a.id,
+    title: a.title,
+    source_name: a.source_name,
+    published_at: a.published_at,
+  }));
 
-  return NextResponse.json({
-    ok: true,
-    product,
-    answer,
-    sources: related.map((a) => ({
-      id: a.id,
-      title: a.title,
-      source_name: a.source_name,
-      published_at: a.published_at,
-    })),
+  const client = new Anthropic({ apiKey });
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const send = (payload: Record<string, unknown>) => controller.enqueue(encoder.encode(sse(payload)));
+      try {
+        send({ type: 'sources', sources });
+
+        const messageStream = client.messages.stream({
+          model: MODEL,
+          max_tokens: 1500,
+          temperature: 0.2,
+          system: SYSTEM_PROMPT,
+          messages: [
+            {
+              role: 'user',
+              content: `製品・部品名: ${product}\n\n参考記事（当サイトが収集した法規制関連記事）:\n${articleContext}`,
+            },
+          ],
+        });
+        messageStream.on('text', (delta) => send({ type: 'delta', text: delta }));
+        const answer = (await messageStream.finalText()).trim();
+
+        // Save for the share URL. A failed insert degrades to "no share
+        // link" — the streamed answer is already on screen.
+        let checkId: string | null = null;
+        try {
+          const { data, error } = await admin
+            .from('regulation_checks')
+            .insert({ product, answer, sources, model: MODEL } as never)
+            .select('id')
+            .single();
+          if (error) throw new Error(error.message);
+          checkId = (data as { id: string }).id;
+        } catch (e) {
+          console.error('[regulation-check] save failed:', (e as Error).message);
+        }
+
+        send({ type: 'done', id: checkId });
+      } catch (e) {
+        send({ type: 'error', error: `AI応答の生成に失敗しました: ${(e as Error).message}` });
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream; charset=utf-8',
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive',
+    },
   });
 }

--- a/src/app/regulation-check/[id]/page.tsx
+++ b/src/app/regulation-check/[id]/page.tsx
@@ -1,0 +1,98 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { supabase } from '@/lib/supabase';
+import { Summary } from '@/components/Summary';
+import { formatDateJST } from '@/lib/format';
+import type { RegulationCheck } from '@/lib/database.types';
+
+// 保存済み結果は不変なので長めにキャッシュしてよい。
+export const revalidate = 3600;
+
+export async function generateMetadata({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const { data } = await supabase
+    .from('regulation_checks')
+    .select('product')
+    .eq('id', id)
+    .single();
+  const product = (data as { product: string } | null)?.product;
+  return {
+    title: product
+      ? `${product} のAI規制チェック結果 | 鹿児島サーキュラーエコノミー情報ポータル`
+      : 'AI規制チェック結果 | 鹿児島サーキュラーエコノミー情報ポータル',
+    description: 'サーキュラーエコノミー関連の法規制と準備事項をAIが簡易整理した結果の共有ページです。',
+  };
+}
+
+export default async function RegulationCheckResult({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const { data, error } = await supabase
+    .from('regulation_checks')
+    .select('id, product, company_name, corporate_number, answer, sources, model, created_at')
+    .eq('id', id)
+    .single();
+
+  if (error || !data) notFound();
+  const check = data as unknown as RegulationCheck;
+
+  return (
+    <article className="space-y-6 max-w-3xl">
+      <nav className="text-sm">
+        <Link href="/regulations" className="text-zinc-500 hover:text-zinc-900 dark:hover:text-zinc-100">← 法規制ページへ</Link>
+      </nav>
+
+      <header className="space-y-2">
+        <p className="text-xs text-zinc-500">
+          AI規制チェック結果 <time className="ml-2">{formatDateJST(check.created_at, 'long')} 実行</time>
+        </p>
+        <h1 className="text-2xl font-semibold tracking-tight">
+          「{check.product}」の関連規制と準備事項
+        </h1>
+        {check.company_name && (
+          <p className="text-sm text-zinc-600 dark:text-zinc-400">対象企業: {check.company_name}</p>
+        )}
+      </header>
+
+      <section className="rounded-lg border border-indigo-200 dark:border-indigo-900 bg-white dark:bg-zinc-900 p-5 space-y-3">
+        <Summary markdown={check.answer} className="text-sm text-zinc-800 dark:text-zinc-200" />
+        {check.model && (
+          <p className="text-[10px] text-zinc-400">by {check.model}</p>
+        )}
+      </section>
+
+      {check.sources.length > 0 && (
+        <section className="space-y-1.5">
+          <p className="text-xs font-medium text-zinc-500">参考にした収集記事:</p>
+          <ul className="space-y-1">
+            {check.sources.map((s) => (
+              <li key={s.id} className="text-sm">
+                <Link href={`/news/${s.id}`} className="text-blue-700 dark:text-blue-400 hover:underline">
+                  {s.title}
+                </Link>
+                <span className="text-xs text-zinc-400 ml-1.5">（{s.source_name}）</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      <section className="pt-4 border-t border-zinc-200 dark:border-zinc-800 space-y-3">
+        <p className="text-xs text-zinc-500">
+          AIによる簡易的な情報整理であり、法的助言ではありません。実行時点の収集記事に基づくため、最新の規制動向は
+          <Link href="/regulations" className="text-blue-700 dark:text-blue-400 hover:underline mx-0.5">法規制ページ</Link>
+          と公式情報でご確認ください。
+        </p>
+        <Link
+          href="/regulations"
+          className="inline-flex items-center gap-1 rounded-md bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium px-4 py-2 transition-colors"
+        >
+          自分でもチェックしてみる
+        </Link>
+      </section>
+    </article>
+  );
+}

--- a/src/components/RegulationCheck.tsx
+++ b/src/components/RegulationCheck.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import Link from 'next/link';
 import { Summary } from '@/components/Summary';
 
@@ -11,12 +11,31 @@ interface SourceRef {
   published_at: string | null;
 }
 
+type StreamEvent =
+  | { type: 'sources'; sources: SourceRef[] }
+  | { type: 'delta'; text: string }
+  | { type: 'done'; id: string | null }
+  | { type: 'error'; error: string };
+
 export function RegulationCheck() {
   const [product, setProduct] = useState('');
   const [loading, setLoading] = useState(false);
   const [answer, setAnswer] = useState<string | null>(null);
   const [sources, setSources] = useState<SourceRef[]>([]);
+  const [shareId, setShareId] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // 逐次 setState だと描画が過剰になるので、バッファに溜めて rAF でまとめて反映。
+  const bufferRef = useRef('');
+  const flushTimerRef = useRef<number | null>(null);
+
+  function flushSoon() {
+    if (flushTimerRef.current !== null) return;
+    flushTimerRef.current = window.requestAnimationFrame(() => {
+      flushTimerRef.current = null;
+      setAnswer(bufferRef.current);
+    });
+  }
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();
@@ -26,23 +45,58 @@ export function RegulationCheck() {
     setError(null);
     setAnswer(null);
     setSources([]);
+    setShareId(null);
+    setCopied(false);
+    bufferRef.current = '';
     try {
       const res = await fetch('/api/regulation-check', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ product: q }),
       });
-      const json = await res.json();
-      if (res.ok && json.ok) {
-        setAnswer(json.answer);
-        setSources(json.sources ?? []);
-      } else {
-        setError(json.error ?? 'エラーが発生しました');
+      const contentType = res.headers.get('content-type') ?? '';
+      if (!res.ok || !contentType.includes('text/event-stream')) {
+        const json = await res.json().catch(() => null);
+        throw new Error(json?.error ?? 'エラーが発生しました');
       }
+      const reader = res.body!.getReader();
+      const decoder = new TextDecoder();
+      let pending = '';
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        pending += decoder.decode(value, { stream: true });
+        // SSE frames are separated by a blank line.
+        const frames = pending.split('\n\n');
+        pending = frames.pop() ?? '';
+        for (const frame of frames) {
+          const data = frame.split('\n').find((l) => l.startsWith('data: '))?.slice(6);
+          if (!data) continue;
+          const ev = JSON.parse(data) as StreamEvent;
+          if (ev.type === 'sources') setSources(ev.sources);
+          else if (ev.type === 'delta') {
+            bufferRef.current += ev.text;
+            flushSoon();
+          } else if (ev.type === 'done') setShareId(ev.id);
+          else if (ev.type === 'error') throw new Error(ev.error);
+        }
+      }
+      setAnswer(bufferRef.current || null);
     } catch (err) {
       setError((err as Error).message);
     } finally {
       setLoading(false);
+    }
+  }
+
+  async function copyShareLink() {
+    if (!shareId) return;
+    try {
+      await navigator.clipboard.writeText(`${window.location.origin}/regulation-check/${shareId}`);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setError('コピーに失敗しました');
     }
   }
 
@@ -72,9 +126,9 @@ export function RegulationCheck() {
         </button>
       </form>
 
-      {loading && (
+      {loading && !answer && (
         <p className="text-sm text-indigo-900/70 dark:text-indigo-200/70">
-          関連する規制記事を検索し、AIが整理しています（10秒ほどかかります）…
+          関連する規制記事を検索しています…
         </p>
       )}
       {error && <p className="text-sm text-red-700 dark:text-red-400">✗ {error}</p>}
@@ -82,7 +136,7 @@ export function RegulationCheck() {
       {answer && (
         <div className="rounded-md bg-white dark:bg-zinc-900 border border-indigo-200 dark:border-indigo-900 p-4 space-y-3">
           <Summary markdown={answer} className="text-sm text-zinc-800 dark:text-zinc-200" />
-          {sources.length > 0 && (
+          {!loading && sources.length > 0 && (
             <div className="pt-2 border-t border-zinc-200 dark:border-zinc-800">
               <p className="text-xs font-medium text-zinc-500 mb-1.5">参考にした収集記事:</p>
               <ul className="space-y-1">
@@ -95,6 +149,23 @@ export function RegulationCheck() {
                   </li>
                 ))}
               </ul>
+            </div>
+          )}
+          {!loading && shareId && (
+            <div className="flex items-center gap-2 pt-2 border-t border-zinc-200 dark:border-zinc-800">
+              <button
+                type="button"
+                onClick={copyShareLink}
+                className="px-3 py-1.5 rounded-md border border-indigo-300 dark:border-indigo-800 text-xs font-medium text-indigo-700 dark:text-indigo-300 hover:bg-indigo-50 dark:hover:bg-indigo-950/40"
+              >
+                {copied ? '✓ コピーしました' : 'この結果の共有リンクをコピー'}
+              </button>
+              <Link
+                href={`/regulation-check/${shareId}`}
+                className="text-xs text-indigo-700 dark:text-indigo-300 hover:underline"
+              >
+                結果ページを開く ↗
+              </Link>
             </div>
           )}
           <p className="text-[11px] text-zinc-400">

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -70,6 +70,25 @@ export type Subsidy = {
   created_at: string;
 }
 
+// 規制チェック結果の出典記事（sources jsonb の要素）。
+export type RegulationCheckSource = {
+  id: string;
+  title: string;
+  source_name: string;
+  published_at: string | null;
+}
+
+export type RegulationCheck = {
+  id: string;
+  product: string;
+  company_name: string | null;
+  corporate_number: string | null;
+  answer: string;
+  sources: RegulationCheckSource[];
+  model: string | null;
+  created_at: string;
+}
+
 // Row returned by the match_news_articles RPC (vector search).
 export type MatchedArticle = {
   id: string;
@@ -93,6 +112,7 @@ export interface Database {
       subsidies: { Row: Subsidy; Insert: Partial<Subsidy> & Pick<Subsidy, 'name' | 'issuer' | 'issuer_level' | 'source_url'>; Update: Partial<Subsidy>; Relationships: [] };
       system_meta: { Row: SystemMeta; Insert: Partial<SystemMeta> & Pick<SystemMeta, 'key'>; Update: Partial<SystemMeta>; Relationships: [] };
       mail_recipients: { Row: MailRecipient; Insert: Partial<MailRecipient> & Pick<MailRecipient, 'email'>; Update: Partial<MailRecipient>; Relationships: [] };
+      regulation_checks: { Row: RegulationCheck; Insert: Partial<RegulationCheck> & Pick<RegulationCheck, 'product' | 'answer'>; Update: Partial<RegulationCheck>; Relationships: [] };
     };
     Views: { [_ in never]: never };
     Functions: {

--- a/supabase/migrations/20260713000000_add_regulation_checks.sql
+++ b/supabase/migrations/20260713000000_add_regulation_checks.sql
@@ -1,0 +1,21 @@
+-- AI規制チェックの結果保存（共有URL用）。
+-- 挿入は service role のみ（anon の insert ポリシーは付けない）。
+-- 共有URLを知っていれば誰でも閲覧できる想定で select は public。
+create table if not exists regulation_checks (
+  id uuid primary key default gen_random_uuid(),
+  product text not null,
+  -- 企業検索機能（gBizINFO 連携）で選択した企業。手入力チェックでは null。
+  company_name text,
+  corporate_number text,
+  answer text not null,
+  sources jsonb not null default '[]',
+  model text,
+  created_at timestamptz not null default now()
+);
+
+alter table regulation_checks enable row level security;
+
+create policy "regulation_checks readable by anyone"
+  on regulation_checks for select using (true);
+
+create index if not exists regulation_checks_created_idx on regulation_checks (created_at desc);


### PR DESCRIPTION
## Summary
AI規制チェックに2つの機能を追加しました。

### ストリーミング応答
- `/api/regulation-check` を SSE（Server-Sent Events）化。`sources`（出典記事、検索完了時点で先行送信）→ `delta`（生成テキスト逐次）→ `done`（保存済み結果の id）の順にイベント送信
- クライアントは受信テキストを requestAnimationFrame でバッファリングしながら逐次描画。10秒無言だった体感を大きく改善
- 入力バリデーション・レート制限（10回/時/IP）は従来どおりストリーム開始前に JSON エラーで返す

### 結果の共有URL・保存
- 新テーブル `regulation_checks`（マイグレーション適用済み・ローカル同期済み）。RLS 有効、select のみ public（URLを知っている人は誰でも閲覧可）、insert は service role のみ
- 生成完了時に自動保存し、「共有リンクをコピー」ボタンと結果ページ `/regulation-check/[id]` を提供
- 共有ページには出典記事リンク・実行日時・使用モデル・免責・「自分でもチェックしてみる」CTA を表示
- 保存失敗時は共有リンクなしに劣化（回答表示は妨げない）
- 次フェーズの gBizINFO 企業検索連携用に `company_name` / `corporate_number` カラムを先行追加

## Test plan
- [x] ローカル dev サーバーで SSE を実測: sources → delta×26 → done(id) を確認（7.0秒で完走）
- [x] 保存された id の共有ページが HTTP 200 で描画（タイトル・回答・モデル名・CTA）
- [x] 存在しない id は 404
- [x] `npm run build` / `npm run lint` 成功
- [x] テスト実行で作成した行は削除済み
- [ ] マージ後、本番 /regulations でストリーミング表示と共有リンクを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)