### PR TITLE
feat(regulation-check): 企業検索→製品サジェスト→規制チェックの導線

### DIFF
--- a/src/app/api/company-search/route.ts
+++ b/src/app/api/company-search/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from 'next/server';
+import { searchCompanies } from '@/lib/gbizinfo';
+
+export const runtime = 'nodejs';
+export const maxDuration = 30;
+
+// gBizINFO を叩くプロキシ。入力補完（デバウンス済み）から呼ばれるため、
+// クエリ単位のメモリキャッシュと IP 単位のレート制限で外部 API を保護する。
+const CACHE_TTL_MS = 60 * 60 * 1000;
+const CACHE_MAX = 500;
+const cache = new Map<string, { at: number; body: unknown }>();
+
+const RATE_LIMIT = 30;
+const RATE_WINDOW_MS = 60 * 1000;
+const hits = new Map<string, number[]>();
+
+function rateLimited(ip: string): boolean {
+  const now = Date.now();
+  const list = (hits.get(ip) ?? []).filter((t) => now - t < RATE_WINDOW_MS);
+  if (list.length >= RATE_LIMIT) return true;
+  list.push(now);
+  hits.set(ip, list);
+  if (hits.size > 5000) hits.clear();
+  return false;
+}
+
+export async function GET(req: Request) {
+  const ip = (req.headers.get('x-forwarded-for') ?? 'unknown').split(',')[0].trim();
+  if (rateLimited(ip)) {
+    return NextResponse.json({ error: '検索回数の上限に達しました。少しおいて再度お試しください' }, { status: 429 });
+  }
+
+  const q = (new URL(req.url).searchParams.get('q') ?? '').trim();
+  if (q.length < 2 || q.length > 60) {
+    return NextResponse.json({ error: '企業名は2〜60文字で入力してください' }, { status: 400 });
+  }
+
+  const cached = cache.get(q);
+  if (cached && Date.now() - cached.at < CACHE_TTL_MS) {
+    return NextResponse.json(cached.body);
+  }
+
+  try {
+    const companies = await searchCompanies(q);
+    const body = { ok: true, companies };
+    if (cache.size > CACHE_MAX) cache.clear();
+    cache.set(q, { at: Date.now(), body });
+    return NextResponse.json(body);
+  } catch (e) {
+    const status = (e as { status?: number }).status === 503 ? 503 : 502;
+    const msg =
+      status === 503
+        ? '企業検索が未設定です（GBIZINFO_API_TOKEN）'
+        : '企業情報の取得に失敗しました。しばらくして再度お試しください';
+    console.error('[company-search]', (e as Error).message);
+    return NextResponse.json({ error: msg }, { status });
+  }
+}

--- a/src/app/api/product-suggest/route.ts
+++ b/src/app/api/product-suggest/route.ts
@@ -1,0 +1,114 @@
+import { NextResponse } from 'next/server';
+import Anthropic from '@anthropic-ai/sdk';
+import { fetchCompanyProfile, profileToText } from '@/lib/gbizinfo';
+
+export const runtime = 'nodejs';
+export const maxDuration = 60;
+
+const MODEL = 'claude-haiku-4-5-20251001';
+// Haiku 4.5 は基本版の web_search のみ対応（_20260209 系は Opus/Sonnet 4.6+）。
+const WEB_SEARCH_TOOL = { type: 'web_search_20250305' as const, name: 'web_search' as const, max_uses: 3 };
+
+const RATE_LIMIT = 10;
+const RATE_WINDOW_MS = 60 * 60 * 1000;
+const hits = new Map<string, number[]>();
+
+function rateLimited(ip: string): boolean {
+  const now = Date.now();
+  const list = (hits.get(ip) ?? []).filter((t) => now - t < RATE_WINDOW_MS);
+  if (list.length >= RATE_LIMIT) return true;
+  list.push(now);
+  hits.set(ip, list);
+  if (hits.size > 5000) hits.clear();
+  return false;
+}
+
+const SYSTEM_PROMPT = `あなたは企業の公表データから、その企業が製造・販売・取り扱いしていそうな製品・部品・素材を推定するアシスタントです。推定した製品名は、サーキュラーエコノミー関連の法規制チェック（ESPR・電池規則・プラ新法など）の入力に使われます。
+
+出力: JSON配列のみを返す。説明文・コードフェンス禁止。
+- 要素は製品・部品・素材名の文字列（2〜20文字、日本語）
+- 3〜6件。規制チェックの入力として意味のある具体性で（例:「リチウムイオン電池」「プラスチック容器」「鉄スクラップ」。「製品」「サービス」のような抽象語は禁止）
+- 公表データに根拠のあるものを優先し、業種からの一般的な推定は後ろに置く
+- 推定できない場合は空配列 [] を返す`;
+
+export async function POST(req: Request) {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) return NextResponse.json({ error: 'AI機能が未設定です' }, { status: 503 });
+
+  const ip = (req.headers.get('x-forwarded-for') ?? 'unknown').split(',')[0].trim();
+  if (rateLimited(ip)) {
+    return NextResponse.json({ error: '利用回数の上限に達しました。1時間ほどおいて再度お試しください' }, { status: 429 });
+  }
+
+  let corporateNumber: string;
+  let useWebSearch: boolean;
+  try {
+    const body = (await req.json()) as { corporate_number?: string; use_web_search?: boolean };
+    corporateNumber = (body.corporate_number ?? '').trim();
+    useWebSearch = body.use_web_search === true;
+  } catch {
+    return NextResponse.json({ error: 'expected JSON body { corporate_number }' }, { status: 400 });
+  }
+  if (!/^\d{13}$/.test(corporateNumber)) {
+    return NextResponse.json({ error: '法人番号が不正です' }, { status: 400 });
+  }
+
+  let profile;
+  try {
+    profile = await fetchCompanyProfile(corporateNumber);
+  } catch (e) {
+    console.error('[product-suggest] profile fetch failed:', (e as Error).message);
+    const status = (e as { status?: number }).status === 503 ? 503 : 502;
+    return NextResponse.json({ error: '企業情報の取得に失敗しました' }, { status });
+  }
+  if (!profile) return NextResponse.json({ error: '企業が見つかりませんでした' }, { status: 404 });
+
+  const client = new Anthropic({ apiKey });
+  try {
+    const res = await client.messages.create({
+      model: MODEL,
+      max_tokens: 2000,
+      temperature: 0.2,
+      system: SYSTEM_PROMPT,
+      tools: useWebSearch ? [WEB_SEARCH_TOOL] : undefined,
+      messages: [
+        {
+          role: 'user',
+          content: `以下の企業が扱っていそうな製品・部品・素材を推定してください。${
+            useWebSearch ? '公表データが薄い場合は企業名でWeb検索し、公式サイトの事業内容も参考にしてください。' : ''
+          }\n\n${profileToText(profile)}`,
+        },
+      ],
+    });
+    const text = res.content
+      .filter((b): b is Anthropic.TextBlock => b.type === 'text')
+      .map((b) => b.text)
+      .join('\n');
+    const products = parseProducts(text);
+    return NextResponse.json({
+      ok: true,
+      company: { corporate_number: profile.corporate_number, name: profile.name, location: profile.location },
+      products,
+      used_web_search: useWebSearch,
+    });
+  } catch (e) {
+    return NextResponse.json({ error: `AI応答の生成に失敗しました: ${(e as Error).message}` }, { status: 502 });
+  }
+}
+
+// コードフェンスや前置きが混ざっても配列部分だけ拾う寛容パース。
+function parseProducts(text: string): string[] {
+  const match = text.match(/\[[\s\S]*?\]/);
+  if (!match) return [];
+  try {
+    const arr = JSON.parse(match[0]) as unknown;
+    if (!Array.isArray(arr)) return [];
+    return arr
+      .filter((v): v is string => typeof v === 'string')
+      .map((v) => v.trim())
+      .filter((v) => v.length >= 2 && v.length <= 40)
+      .slice(0, 6);
+  } catch {
+    return [];
+  }
+}

--- a/src/app/api/regulation-check/route.ts
+++ b/src/app/api/regulation-check/route.ts
@@ -56,9 +56,21 @@ export async function POST(req: Request) {
   }
 
   let product: string;
+  let companyName: string | null = null;
+  let corporateNumber: string | null = null;
   try {
-    const body = (await req.json()) as { product?: string };
+    const body = (await req.json()) as {
+      product?: string;
+      company?: { name?: string; corporate_number?: string };
+    };
     product = (body.product ?? '').trim();
+    // 企業検索フローから来た場合のみ付く。回答のパーソナライズと保存に使う。
+    const name = (body.company?.name ?? '').trim();
+    const num = (body.company?.corporate_number ?? '').trim();
+    if (name.length >= 1 && name.length <= 100 && /^\d{13}$/.test(num)) {
+      companyName = name;
+      corporateNumber = num;
+    }
   } catch {
     return NextResponse.json({ error: 'expected JSON body { product }' }, { status: 400 });
   }
@@ -118,7 +130,9 @@ export async function POST(req: Request) {
           messages: [
             {
               role: 'user',
-              content: `製品・部品名: ${product}\n\n参考記事（当サイトが収集した法規制関連記事）:\n${articleContext}`,
+              content: `製品・部品名: ${product}${
+                companyName ? `\n対象企業: ${companyName}（この企業の立場で実務準備を整理すること）` : ''
+              }\n\n参考記事（当サイトが収集した法規制関連記事）:\n${articleContext}`,
             },
           ],
         });
@@ -131,7 +145,14 @@ export async function POST(req: Request) {
         try {
           const { data, error } = await admin
             .from('regulation_checks')
-            .insert({ product, answer, sources, model: MODEL } as never)
+            .insert({
+              product,
+              answer,
+              sources,
+              model: MODEL,
+              company_name: companyName,
+              corporate_number: corporateNumber,
+            } as never)
             .select('id')
             .single();
           if (error) throw new Error(error.message);

--- a/src/components/RegulationCheck.tsx
+++ b/src/components/RegulationCheck.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { Summary } from '@/components/Summary';
 
@@ -11,15 +11,37 @@ interface SourceRef {
   published_at: string | null;
 }
 
+interface Company {
+  corporate_number: string;
+  name: string;
+  location: string | null;
+}
+
 type StreamEvent =
   | { type: 'sources'; sources: SourceRef[] }
   | { type: 'delta'; text: string }
   | { type: 'done'; id: string | null }
   | { type: 'error'; error: string };
 
+type Mode = 'product' | 'company';
+
 export function RegulationCheck() {
+  const [mode, setMode] = useState<Mode>('product');
   const [product, setProduct] = useState('');
+
+  // 企業検索フロー
+  const [companyQuery, setCompanyQuery] = useState('');
+  const [companyHits, setCompanyHits] = useState<Company[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [company, setCompany] = useState<Company | null>(null);
+  const [useWebSearch, setUseWebSearch] = useState(false);
+  const [suggesting, setSuggesting] = useState(false);
+  const [products, setProducts] = useState<string[]>([]);
+  const [suggestNote, setSuggestNote] = useState<string | null>(null);
+
+  // 規制チェック（共通）
   const [loading, setLoading] = useState(false);
+  const [checkedProduct, setCheckedProduct] = useState<string | null>(null);
   const [answer, setAnswer] = useState<string | null>(null);
   const [sources, setSources] = useState<SourceRef[]>([]);
   const [shareId, setShareId] = useState<string | null>(null);
@@ -37,9 +59,71 @@ export function RegulationCheck() {
     });
   }
 
-  async function submit(e: React.FormEvent) {
-    e.preventDefault();
-    const q = product.trim();
+  // 企業名のインクリメンタル検索（400ms デバウンス）
+  useEffect(() => {
+    const q = companyQuery.trim();
+    if (mode !== 'company' || q.length < 2 || (company && q === company.name)) {
+      setCompanyHits([]);
+      setSearching(false);
+      return;
+    }
+    setSearching(true);
+    const timer = window.setTimeout(async () => {
+      try {
+        const res = await fetch(`/api/company-search?q=${encodeURIComponent(q)}`);
+        const json = await res.json();
+        if (res.ok && json.ok) {
+          setCompanyHits(json.companies ?? []);
+          setError(null);
+        } else {
+          setCompanyHits([]);
+          setError(json.error ?? '企業検索でエラーが発生しました');
+        }
+      } catch {
+        setCompanyHits([]);
+      } finally {
+        setSearching(false);
+      }
+    }, 400);
+    return () => window.clearTimeout(timer);
+  }, [companyQuery, mode, company]);
+
+  function selectCompany(c: Company) {
+    setCompany(c);
+    setCompanyQuery(c.name);
+    setCompanyHits([]);
+    setProducts([]);
+    setSuggestNote(null);
+  }
+
+  async function suggestProducts() {
+    if (!company || suggesting) return;
+    setSuggesting(true);
+    setError(null);
+    setProducts([]);
+    setSuggestNote(null);
+    try {
+      const res = await fetch('/api/product-suggest', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ corporate_number: company.corporate_number, use_web_search: useWebSearch }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.ok) throw new Error(json.error ?? 'エラーが発生しました');
+      const list = (json.products ?? []) as string[];
+      setProducts(list);
+      if (list.length === 0) {
+        setSuggestNote('公表データから製品を推定できませんでした。下の入力欄に製品名を直接入力してください。');
+      }
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setSuggesting(false);
+    }
+  }
+
+  async function runCheck(target: string) {
+    const q = target.trim();
     if (!q || loading) return;
     setLoading(true);
     setError(null);
@@ -47,12 +131,18 @@ export function RegulationCheck() {
     setSources([]);
     setShareId(null);
     setCopied(false);
+    setCheckedProduct(q);
     bufferRef.current = '';
     try {
       const res = await fetch('/api/regulation-check', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ product: q }),
+        body: JSON.stringify({
+          product: q,
+          ...(mode === 'company' && company
+            ? { company: { name: company.name, corporate_number: company.corporate_number } }
+            : {}),
+        }),
       });
       const contentType = res.headers.get('content-type') ?? '';
       if (!res.ok || !contentType.includes('text/event-stream')) {
@@ -100,28 +190,141 @@ export function RegulationCheck() {
     }
   }
 
+  const inputClass =
+    'flex-1 min-w-[200px] px-3 py-2 text-sm border border-indigo-300 dark:border-indigo-800 rounded-md bg-white dark:bg-zinc-900';
+  const buttonClass =
+    'px-5 py-2 rounded-md bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-700 disabled:opacity-50';
+
   return (
     <section className="rounded-lg border border-indigo-200 dark:border-indigo-900 bg-indigo-50/50 dark:bg-indigo-950/20 p-5 space-y-3">
       <div>
         <h2 className="font-semibold text-indigo-950 dark:text-indigo-100">AI規制チェック（β）</h2>
         <p className="mt-1 text-xs text-indigo-900/70 dark:text-indigo-200/70">
-          製品・部品・素材名を入力すると、関係しうる法規制と準備事項をAIが簡易整理します。例: リチウムイオン電池、プラスチック容器、鉄スクラップ
+          {mode === 'product'
+            ? '製品・部品・素材名を入力すると、関係しうる法規制と準備事項をAIが簡易整理します。例: リチウムイオン電池、プラスチック容器、鉄スクラップ'
+            : '企業名で検索すると、公表データ（gBizINFO）からその企業の製品をAIが推定し、法規制チェックにつなげます。'}
         </p>
       </div>
-      <form onSubmit={submit} className="flex flex-wrap gap-2">
+
+      <div className="flex gap-1 rounded-md bg-indigo-100/70 dark:bg-indigo-900/30 p-1 w-fit" role="tablist">
+        {(
+          [
+            ['product', '製品名から'],
+            ['company', '企業名から'],
+          ] as const
+        ).map(([m, label]) => (
+          <button
+            key={m}
+            type="button"
+            role="tab"
+            aria-selected={mode === m}
+            onClick={() => setMode(m)}
+            className={
+              mode === m
+                ? 'px-3 py-1 rounded text-xs font-medium bg-white dark:bg-zinc-900 text-indigo-900 dark:text-indigo-100 shadow-sm'
+                : 'px-3 py-1 rounded text-xs text-indigo-800/70 dark:text-indigo-200/70 hover:text-indigo-900 dark:hover:text-indigo-100'
+            }
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {mode === 'company' && (
+        <div className="space-y-2">
+          <div className="relative">
+            <input
+              type="text"
+              value={companyQuery}
+              onChange={(e) => {
+                setCompanyQuery(e.target.value);
+                setCompany(null);
+                setProducts([]);
+              }}
+              maxLength={60}
+              placeholder="企業名を入力して検索…"
+              className={`${inputClass} w-full`}
+            />
+            {searching && (
+              <span className="absolute right-3 top-2.5 text-xs text-zinc-400">検索中…</span>
+            )}
+            {companyHits.length > 0 && (
+              <ul className="absolute z-10 mt-1 w-full rounded-md border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 shadow-lg max-h-64 overflow-y-auto">
+                {companyHits.map((c) => (
+                  <li key={c.corporate_number}>
+                    <button
+                      type="button"
+                      onClick={() => selectCompany(c)}
+                      className="w-full text-left px-3 py-2 text-sm hover:bg-indigo-50 dark:hover:bg-indigo-950/40"
+                    >
+                      <span className="font-medium">{c.name}</span>
+                      <span className="ml-2 text-xs text-zinc-500">
+                        {c.location ?? ''}（法人番号 {c.corporate_number}）
+                      </span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          {company && (
+            <div className="flex flex-wrap items-center gap-3">
+              <label className="flex items-center gap-1.5 text-xs text-indigo-900/80 dark:text-indigo-200/80">
+                <input
+                  type="checkbox"
+                  checked={useWebSearch}
+                  onChange={(e) => setUseWebSearch(e.target.checked)}
+                  className="rounded border-indigo-300"
+                />
+                Web検索も使って精度を上げる（少し時間がかかります）
+              </label>
+              <button type="button" onClick={suggestProducts} disabled={suggesting} className={buttonClass}>
+                {suggesting ? '推定中…' : '製品候補を出す'}
+              </button>
+            </div>
+          )}
+
+          {products.length > 0 && (
+            <div className="space-y-1.5">
+              <p className="text-xs font-medium text-indigo-900/70 dark:text-indigo-200/70">
+                推定された製品（タップで規制チェック）:
+              </p>
+              <div className="flex flex-wrap gap-1.5">
+                {products.map((p) => (
+                  <button
+                    key={p}
+                    type="button"
+                    onClick={() => runCheck(p)}
+                    disabled={loading}
+                    className="rounded-full border border-indigo-300 dark:border-indigo-700 bg-white dark:bg-zinc-900 px-3 py-1 text-sm text-indigo-900 dark:text-indigo-100 hover:bg-indigo-100 dark:hover:bg-indigo-950/60 disabled:opacity-50"
+                  >
+                    {p}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+          {suggestNote && <p className="text-xs text-zinc-500">{suggestNote}</p>}
+        </div>
+      )}
+
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          runCheck(product);
+        }}
+        className="flex flex-wrap gap-2"
+      >
         <input
           type="text"
           value={product}
           onChange={(e) => setProduct(e.target.value)}
           maxLength={40}
-          placeholder="製品・部品名を入力…"
-          className="flex-1 min-w-[200px] px-3 py-2 text-sm border border-indigo-300 dark:border-indigo-800 rounded-md bg-white dark:bg-zinc-900"
+          placeholder={mode === 'company' ? '製品名を直接入力する場合はこちら…' : '製品・部品名を入力…'}
+          className={inputClass}
         />
-        <button
-          type="submit"
-          disabled={loading || product.trim().length < 2}
-          className="px-5 py-2 rounded-md bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-700 disabled:opacity-50"
-        >
+        <button type="submit" disabled={loading || product.trim().length < 2} className={buttonClass}>
           {loading ? '分析中…' : 'チェック'}
         </button>
       </form>
@@ -135,6 +338,12 @@ export function RegulationCheck() {
 
       {answer && (
         <div className="rounded-md bg-white dark:bg-zinc-900 border border-indigo-200 dark:border-indigo-900 p-4 space-y-3">
+          {checkedProduct && (
+            <p className="text-xs text-zinc-500">
+              「{checkedProduct}」のチェック結果
+              {mode === 'company' && company ? `（対象企業: ${company.name}）` : ''}
+            </p>
+          )}
           <Summary markdown={answer} className="text-sm text-zinc-800 dark:text-zinc-200" />
           {!loading && sources.length > 0 && (
             <div className="pt-2 border-t border-zinc-200 dark:border-zinc-800">

--- a/src/lib/gbizinfo.ts
+++ b/src/lib/gbizinfo.ts
@@ -1,0 +1,123 @@
+// gBizINFO REST API v2 クライアント（経産省の法人情報 API）。
+// 認証は X-hojinInfo-api-token ヘッダー。トークンは無料の利用申請で取得し、
+// GBIZINFO_API_TOKEN に設定する。サーバー側専用 — クライアントに露出させない。
+// 仕様: https://api.info.gbiz.go.jp/hojin/swagger-ui/index.html?urls.primaryName=v2
+const BASE_URL = 'https://api.info.gbiz.go.jp/hojin/v2';
+
+export interface CompanySearchHit {
+  corporate_number: string;
+  name: string;
+  location: string | null;
+}
+
+export interface CompanyProfile extends CompanySearchHit {
+  company_url: string | null;
+  business_summary: string | null;
+  business_items: string[];
+  employee_number: number | null;
+  capital_stock: number | null;
+  date_of_establishment: string | null;
+  certifications: string[];
+  subsidies: string[];
+  patents: string[];
+}
+
+class GbizError extends Error {
+  constructor(message: string, readonly status: number) {
+    super(message);
+  }
+}
+
+async function gbizFetch(path: string, params: Record<string, string>): Promise<unknown> {
+  const token = process.env.GBIZINFO_API_TOKEN;
+  if (!token) throw new GbizError('GBIZINFO_API_TOKEN not set', 503);
+  const url = `${BASE_URL}${path}?${new URLSearchParams(params)}`;
+  const res = await fetch(url, {
+    headers: { 'X-hojinInfo-api-token': token, Accept: 'application/json' },
+    cache: 'no-store',
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!res.ok) throw new GbizError(`gBizINFO ${path} failed: ${res.status}`, res.status);
+  return res.json();
+}
+
+type HojinRow = Record<string, unknown>;
+
+function rows(json: unknown): HojinRow[] {
+  return ((json as Record<string, unknown>)?.['hojin-infos'] as HojinRow[]) ?? [];
+}
+
+function str(v: unknown): string | null {
+  return typeof v === 'string' && v.trim() !== '' ? v.trim() : null;
+}
+
+function num(v: unknown): number | null {
+  return typeof v === 'number' ? v : null;
+}
+
+function titles(v: unknown, limit: number): string[] {
+  if (!Array.isArray(v)) return [];
+  return v
+    .map((item) => str((item as HojinRow)?.title))
+    .filter((t): t is string => t !== null)
+    .slice(0, limit);
+}
+
+export async function searchCompanies(name: string, limit = 8): Promise<CompanySearchHit[]> {
+  const json = await gbizFetch('/hojin', { name, limit: String(limit), page: '1' });
+  return rows(json)
+    .map((r) => ({
+      corporate_number: str(r.corporate_number) ?? '',
+      name: str(r.name) ?? '',
+      location: str(r.location),
+    }))
+    .filter((c) => c.corporate_number !== '' && c.name !== '');
+}
+
+// 法人基本情報＋公表データ（届出認定・補助金・特許のタイトル）をまとめて取得。
+// 付随情報は欠けても致命的ではないので、失敗は握りつぶして空配列にする。
+export async function fetchCompanyProfile(corporateNumber: string): Promise<CompanyProfile | null> {
+  const basicJson = await gbizFetch(`/hojin/${corporateNumber}`, {});
+  const basic = rows(basicJson)[0];
+  if (!basic) return null;
+
+  const [cert, subsidy, patent] = await Promise.all(
+    (['certification', 'subsidy', 'patent'] as const).map((kind) =>
+      gbizFetch(`/hojin/${corporateNumber}/${kind}`, {}).catch(() => null),
+    ),
+  );
+
+  return {
+    corporate_number: corporateNumber,
+    name: str(basic.name) ?? '',
+    location: str(basic.location),
+    company_url: str(basic.company_url),
+    business_summary: str(basic.business_summary),
+    business_items: Array.isArray(basic.business_items)
+      ? basic.business_items.map((b) => str(b)).filter((b): b is string => b !== null).slice(0, 10)
+      : [],
+    employee_number: num(basic.employee_number),
+    capital_stock: num(basic.capital_stock),
+    date_of_establishment: str(basic.date_of_establishment),
+    certifications: titles(rows(cert)[0]?.certification, 10),
+    subsidies: titles(rows(subsidy)[0]?.subsidy, 10),
+    patents: titles(rows(patent)[0]?.patent, 10),
+  };
+}
+
+// AI に渡す企業プロフィールのテキスト表現。
+export function profileToText(p: CompanyProfile): string {
+  const lines = [
+    `企業名: ${p.name}（法人番号 ${p.corporate_number}）`,
+    p.location && `所在地: ${p.location}`,
+    p.company_url && `Webサイト: ${p.company_url}`,
+    p.business_summary && `事業概要: ${p.business_summary}`,
+    p.business_items.length > 0 && `事業内容: ${p.business_items.join('、')}`,
+    p.employee_number !== null && `従業員数: ${p.employee_number}名`,
+    p.capital_stock !== null && `資本金: ${p.capital_stock.toLocaleString()}円`,
+    p.certifications.length > 0 && `届出・認定: ${p.certifications.join('、')}`,
+    p.subsidies.length > 0 && `受給補助金: ${p.subsidies.join('、')}`,
+    p.patents.length > 0 && `特許・商標: ${p.patents.join('、')}`,
+  ];
+  return lines.filter(Boolean).join('\n');
+}


### PR DESCRIPTION
## Summary
AI規制チェックに「企業名から」モードを追加しました。企業名を入力すると gBizINFO（経産省の法人情報API）から企業をサジェストし、選択した企業の公表データからAIが製品候補を推定、タップで既存の規制チェックにつながります。

### 構成
- **`src/lib/gbizinfo.ts`** — gBizINFO REST API v2 クライアント。企業検索（全国・部分一致）と、法人基本情報＋届出認定・補助金・特許タイトルの取得。トークンはサーバー側のみで使用
- **`GET /api/company-search?q=`** — 検索プロキシ。クエリ単位1時間キャッシュ＋30回/分/IPのレート制限
- **`POST /api/product-suggest`** — 公表データを Claude Haiku 4.5 に渡し製品・素材候補を3〜6件推定（JSON配列を寛容パース）。`use_web_search: true` で Anthropic の web_search ツール（max 3回）を併用し企業公式サイトも参照
- **`/api/regulation-check`** — `company` を受け取り、プロンプトに「この企業の立場で整理」を追加、`regulation_checks.company_name / corporate_number` に保存（共有ページに表示）
- **UI** — 「製品名から / 企業名から」セグメント切替。企業検索は400msデバウンス、Web検索はチェックボックスでオプトイン

### 環境変数
- `GBIZINFO_API_TOKEN` — .env.local 設定済み・Vercel Production 設定済み（Preview は CLI 不具合で未設定 → 未設定環境では「企業検索が未設定です」に劣化）

## Test plan
- [x] gBizINFO v2 の実在・認証・レスポンス形式を仕様（Swagger）と実フェッチで検証
- [x] 企業検索: 「トヨタ自動車」「南国殖産」で実ヒット（法人番号・所在地付き）
- [x] 製品サジェスト: トヨタ自動車 →「リチウムイオン電池・触媒コンバーター…」、南国殖産（Web検索併用）→「太陽光発電システム・蓄電池…」
- [x] 企業コンテキスト付き規制チェック → SSE完走 → 保存 → 共有ページに「対象企業: 南国殖産株式会社」表示
- [x] バリデーション（短すぎるクエリ400、法人番号形式400）
- [x] `npm run build` / `npm run lint` 成功、テスト行は削除済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)